### PR TITLE
Bookworm/Pi5 Compatibility: Upgrade to latest boilerplate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -35,7 +35,7 @@ jobs:
           make build
 
       - name: Upload Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RELEASE_FILE }}
           path: dist/

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,16 +10,15 @@ jobs:
   test:
     name: linting & spelling
     runs-on: ubuntu-latest
-
     env:
       TERM: xterm-256color
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python '3,11'
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -34,3 +33,7 @@ jobs:
       - name: Run Code Checks
         run: |
           make check
+
+      - name: Run Bash Code Checks
+        run: |
+          make shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,13 @@ uninstall:
 
 dev-deps:
 	python3 -m pip install -r requirements-dev.txt
-	sudo apt install dos2unix
+	sudo apt install dos2unix shellcheck
 
 check:
 	@bash check.sh
+
+shellcheck:
+	shellcheck *.sh
 
 qa:
 	tox -e qa

--- a/check.sh
+++ b/check.sh
@@ -6,6 +6,7 @@ NOPOST=$1
 LIBRARY_NAME=`hatch project metadata name`
 LIBRARY_VERSION=`hatch version | awk -F "." '{print $1"."$2"."$3}'`
 POST_VERSION=`hatch version | awk -F "." '{print substr($4,0,length($4))}'`
+TERM=${TERM:="xterm-256color"}
 
 success() {
 	echo -e "$(tput setaf 2)$1$(tput sgr0)"

--- a/check.sh
+++ b/check.sh
@@ -3,9 +3,9 @@
 # This script handles some basic QA checks on the source
 
 NOPOST=$1
-LIBRARY_NAME=`hatch project metadata name`
-LIBRARY_VERSION=`hatch version | awk -F "." '{print $1"."$2"."$3}'`
-POST_VERSION=`hatch version | awk -F "." '{print substr($4,0,length($4))}'`
+LIBRARY_NAME=$(hatch project metadata name)
+LIBRARY_VERSION=$(hatch version | awk -F "." '{print $1"."$2"."$3}')
+POST_VERSION=$(hatch version | awk -F "." '{print substr($4,0,length($4))}')
 TERM=${TERM:="xterm-256color"}
 
 success() {
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	*)
 		if [[ $1 == -* ]]; then
-			printf "Unrecognised option: $1\n";
+			printf "Unrecognised option: %s\n" "$1";
 			exit 1
 		fi
 		POSITIONAL_ARGS+=("$1")
@@ -40,8 +40,7 @@ done
 inform "Checking $LIBRARY_NAME $LIBRARY_VERSION\n"
 
 inform "Checking for trailing whitespace..."
-grep -IUrn --color "[[:blank:]]$" --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=PKG-INFO
-if [[ $? -eq 0 ]]; then
+if grep -IUrn --color "[[:blank:]]$" --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=PKG-INFO; then
     warning "Trailing whitespace found!"
     exit 1
 else
@@ -50,8 +49,7 @@ fi
 printf "\n"
 
 inform "Checking for DOS line-endings..."
-grep -lIUrn --color $'\r' --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=Makefile
-if [[ $? -eq 0 ]]; then
+if grep -lIUrn --color $'\r' --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=Makefile; then
     warning "DOS line-endings found!"
     exit 1
 else
@@ -60,8 +58,7 @@ fi
 printf "\n"
 
 inform "Checking CHANGELOG.md..."
-cat CHANGELOG.md | grep ^${LIBRARY_VERSION} > /dev/null 2>&1
-if [[ $? -eq 1 ]]; then
+if ! grep "^${LIBRARY_VERSION}" CHANGELOG.md > /dev/null 2>&1; then
     warning "Changes missing for version ${LIBRARY_VERSION}! Please update CHANGELOG.md."
     exit 1
 else
@@ -70,8 +67,7 @@ fi
 printf "\n"
 
 inform "Checking for git tag ${LIBRARY_VERSION}..."
-git tag -l | grep -E "${LIBRARY_VERSION}$"
-if [[ $? -eq 1 ]]; then
+if ! git tag -l | grep -E "${LIBRARY_VERSION}$"; then
     warning "Missing git tag for version ${LIBRARY_VERSION}"
 fi
 printf "\n"

--- a/examples/bargraph.py
+++ b/examples/bargraph.py
@@ -3,15 +3,15 @@ import sys
 
 from scd4x import SCD4X
 
-BAR_CHAR = u'\u2588'
+BAR_CHAR = u"\u2588"
 
-ANSI_COLOR_RED = '\x1b[31m'
-ANSI_COLOR_GREEN = '\x1b[32m'
-ANSI_COLOR_YELLOW = '\x1b[33m'
-ANSI_COLOR_BLUE = '\x1b[34m'
-ANSI_COLOR_MAGENTA = '\x1b[35m'
-ANSI_COLOR_BLACK = '\x1b[30m'
-ANSI_COLOR_RESET = '\x1b[0m'
+ANSI_COLOR_RED = "\x1b[31m"
+ANSI_COLOR_GREEN = "\x1b[32m"
+ANSI_COLOR_YELLOW = "\x1b[33m"
+ANSI_COLOR_BLUE = "\x1b[34m"
+ANSI_COLOR_MAGENTA = "\x1b[35m"
+ANSI_COLOR_BLACK = "\x1b[30m"
+ANSI_COLOR_RESET = "\x1b[0m"
 
 
 colours = [ANSI_COLOR_BLUE, ANSI_COLOR_GREEN, ANSI_COLOR_YELLOW, ANSI_COLOR_RED, ANSI_COLOR_MAGENTA]
@@ -55,7 +55,7 @@ try:
         t_reading = "{:.4f}c".format(temperature).ljust(BAR_WIDTH + 14)
         c_reading = "{:.0f}PPM".format(co2).ljust(BAR_WIDTH + 14)
 
-        sys.stdout.write('\x1b[0;1H')
+        sys.stdout.write("\x1b[0;1H")
         sys.stdout.write(u"""{title}
 {blank}
 Temperature: {t_bar}

--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ function do_config_backup {
 		CONFIG_BACKUP=true
 		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
 		inform "Backing up $CONFIG_DIR/$CONFIG_FILE to $CONFIG_DIR/$FILENAME\n"
-		sudo cp "$CONFIG_DIR/$CONFIG_FILE $CONFIG_DIR/$FILENAME"
+		sudo cp "$CONFIG_DIR/$CONFIG_FILE" "$CONFIG_DIR/$FILENAME"
 		mkdir -p "$RESOURCES_TOP_DIR/config-backups/"
 		cp $CONFIG_DIR/$CONFIG_FILE "$RESOURCES_TOP_DIR/config-backups/$FILENAME"
 		if [ -f "$UNINSTALLER" ]; then
@@ -301,7 +301,9 @@ for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG_DIR/$CONFIG_FILE"* ]] || [[ "$CMD" == *"\$CONFIG_DIR/\$CONFIG_FILE"* ]]; then
 		do_config_backup
 	fi
-	printf "\"%s\"\n" "$CMD"
+	if [[ ! "$CMD" == printf* ]]; then
+		printf "Running: \"%s\"\n" "$CMD"
+	fi
 	eval "$CMD"
 	check_for_error
 done

--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 LIBRARY_NAME=`grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}'`
-CONFIG=/boot/config.txt
+CONFIG_FILE=config.txt
+CONFIG_DIR="/boot/firmware"
 DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
-RESOURCES_TOP_DIR=$HOME/Pimoroni
+RESOURCES_TOP_DIR="$HOME/Pimoroni"
+VENV_BASH_SNIPPET="$RESOURCES_TOP_DIR/auto_venv.sh"
+VENV_DIR="$HOME/.virtualenvs/pimoroni"
 WD=`pwd`
 USAGE="./install.sh (--unstable)"
 POSITIONAL_ARGS=()
 FORCE=false
 UNSTABLE=false
-PYTHON="/usr/bin/python3"
+PYTHON="python"
+CMD_ERRORS=false
 
 
 user_check() {
 	if [ $(id -u) -eq 0 ]; then
-		printf "Script should not be run as root. Try './install.sh'\n"
-		exit 1
+		fatal "Script should not be run as root. Try './install.sh'\n"
 	fi
 }
 
@@ -51,19 +54,91 @@ inform() {
 }
 
 warning() {
-	echo -e "$(tput setaf 1)$1$(tput sgr0)"
+	echo -e "$(tput setaf 1)⚠ WARNING:$(tput sgr0) $1"
+}
+
+fatal() {
+	echo -e "$(tput setaf 1)⚠ FATAL:$(tput sgr0) $1"
+	exit 1
+}
+
+find_config() {
+	if [ ! -f "$CONFIG_DIR/$CONFIG_FILE" ]; then
+		CONFIG_DIR="/boot"
+		if [ ! -f "$CONFIG_DIR/$CONFIG_FILE" ]; then
+			fatal "Could not find $CONFIG_FILE!"
+		fi
+	else
+		if [ -f "/boot/$CONFIG_FILE" ] && [ ! -L "/boot/$CONFIG_FILE" ]; then
+			warning "Oops! It looks like /boot/$CONFIG_FILE is not a link to $CONFIG_DIR/$CONFIG_FILE"
+			warning "You might want to fix this!"
+		fi
+	fi
+	inform "Using $CONFIG_FILE in $CONFIG_DIR"
+}
+
+venv_bash_snippet() {
+	inform "Checking for $VENV_BASH_SNIPPET\n"
+	if [ ! -f $VENV_BASH_SNIPPET ]; then
+		inform "Creating $VENV_BASH_SNIPPET\n"
+		mkdir -p $RESOURCES_TOP_DIR
+		cat << EOF > $VENV_BASH_SNIPPET
+# Add "source $VENV_BASH_SNIPPET" to your ~/.bashrc to activate
+# the Pimoroni virtual environment automagically!
+VENV_DIR="$VENV_DIR"
+if [ ! -f \$VENV_DIR/bin/activate ]; then
+  printf "Creating user Python environment in \$VENV_DIR, please wait...\n"
+  mkdir -p \$VENV_DIR
+  python3 -m venv --system-site-packages \$VENV_DIR
+fi
+printf " ↓ ↓ ↓ ↓   Hello, we've activated a Python venv for you. To exit, type \"deactivate\".\n"
+source \$VENV_DIR/bin/activate
+EOF
+	fi
+}
+
+venv_check() {
+	PYTHON_BIN=`which $PYTHON`
+	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
+		printf "This script should be run in a virtual Python environment.\n"
+		if confirm "Would you like us to create and/or use a default one?"; then
+			printf "\n"
+			if [ ! -f $VENV_DIR/bin/activate ]; then
+				inform "Creating a new virtual Python environment in $VENV_DIR, please wait...\n"
+				mkdir -p $VENV_DIR
+				/usr/bin/python3 -m venv $VENV_DIR --system-site-packages
+				venv_bash_snippet
+				source $VENV_DIR/bin/activate
+			else
+				inform "Activating existing virtual Python environment in $VENV_DIR\n"
+				printf "source $VENV_DIR/bin/activate\n"
+				source $VENV_DIR/bin/activate
+			fi
+		else
+			printf "\n"
+			fatal "Please create and/or activate a virtual Python environment and try again!\n"
+		fi
+	fi
+	printf "\n"
+}
+
+check_for_error() {
+	if [ $? -ne 0 ]; then
+		CMD_ERRORS=true
+		warning "^^^ 😬"
+	fi
 }
 
 function do_config_backup {
 	if [ ! $CONFIG_BACKUP == true ]; then
 		CONFIG_BACKUP=true
 		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
-		inform "Backing up $CONFIG to /boot/$FILENAME\n"
-		sudo cp $CONFIG /boot/$FILENAME
+		inform "Backing up $CONFIG_DIR/$CONFIG_FILE to $CONFIG_DIR/$FILENAME\n"
+		sudo cp $CONFIG_DIR/$CONFIG_FILE $CONFIG_DIR/$FILENAME
 		mkdir -p $RESOURCES_TOP_DIR/config-backups/
-		cp $CONFIG $RESOURCES_TOP_DIR/config-backups/$FILENAME
+		cp $CONFIG_DIR/$CONFIG_FILE $RESOURCES_TOP_DIR/config-backups/$FILENAME
 		if [ -f "$UNINSTALLER" ]; then
-			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG" >> $UNINSTALLER
+			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG_DIR/$CONFIG_FILE" >> $UNINSTALLER
 		fi
 	fi
 }
@@ -71,6 +146,7 @@ function do_config_backup {
 function apt_pkg_install {
 	PACKAGES=()
 	PACKAGES_IN=("$@")
+	# Check the list of packages and only run update/install if we need to
 	for ((i = 0; i < ${#PACKAGES_IN[@]}; i++)); do
 		PACKAGE="${PACKAGES_IN[$i]}"
 		if [ "$PACKAGE" == "" ]; then continue; fi
@@ -82,12 +158,14 @@ function apt_pkg_install {
 	done
 	PACKAGES="${PACKAGES[@]}"
 	if ! [ "$PACKAGES" == "" ]; then
-		echo "Installing missing packages: $PACKAGES"
+		printf "\n"
+		inform "Installing missing packages: $PACKAGES"
 		if [ ! $APT_HAS_UPDATED ]; then
 			sudo apt update
 			APT_HAS_UPDATED=true
 		fi
 		sudo apt install -y $PACKAGES
+		check_for_error
 		if [ -f "$UNINSTALLER" ]; then
 			echo "apt uninstall -y $PACKAGES" >> $UNINSTALLER
 		fi
@@ -95,7 +173,9 @@ function apt_pkg_install {
 }
 
 function pip_pkg_install {
+	# A null Keyring prevents pip stalling in the background
 	PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring $PYTHON -m pip install --upgrade "$@"
+	check_for_error
 }
 
 while [[ $# -gt 0 ]]; do
@@ -125,29 +205,33 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-user_check
+printf "Installing $LIBRARY_NAME...\n\n"
 
-if [ ! -f "$PYTHON" ]; then
-	printf "Python path $PYTHON not found!\n"
-	exit 1
+user_check
+venv_check
+
+if [ ! -f `which $PYTHON` ]; then
+	fatal "Python path $PYTHON not found!\n"
 fi
 
 PYTHON_VER=`$PYTHON --version`
 
-printf "$LIBRARY_NAME Python Library: Installer\n\n"
-
 inform "Checking Dependencies. Please wait..."
+
+# Install toml and try to read pyproject.toml into bash variables
 
 pip_pkg_install toml
 
 CONFIG_VARS=`$PYTHON - <<EOF
 import toml
 config = toml.load("pyproject.toml")
-p = dict(config['pimoroni'])
+github_url = config['project']['urls']['GitHub']
+p = dict(config['tool']['pimoroni'])
 # Convert list config entries into bash arrays
 for k, v in p.items():
     v = "'\n\t'".join(v)
     p[k] = f"('{v}')"
+print(f'GITHUB_URL="{github_url}"')
 print("""
 APT_PACKAGES={apt_packages}
 SETUP_CMDS={commands}
@@ -156,8 +240,8 @@ CONFIG_TXT={configtxt}
 EOF`
 
 if [ $? -ne 0 ]; then
-	warning "Error parsing configuration...\n"
-	exit 1
+	# This is bad, this should not happen in production!
+	fatal "Error parsing configuration...\n"
 fi
 
 eval $CONFIG_VARS
@@ -167,6 +251,8 @@ UNINSTALLER=$RESOURCES_DIR/uninstall.sh
 
 RES_DIR_OWNER=`stat -c "%U" $RESOURCES_TOP_DIR`
 
+# Previous install.sh scripts were run as root with sudo, which caused
+# the ~/Pimoroni dir to be created with root ownership. Try and fix it.
 if [[ "$RES_DIR_OWNER" == "root" ]]; then
 	warning "\n\nFixing $RESOURCES_TOP_DIR permissions!\n\n"
 	sudo chown -R $USER:$USER $RESOURCES_TOP_DIR
@@ -174,26 +260,33 @@ fi
 
 mkdir -p $RESOURCES_DIR
 
+# Create a stub uninstaller file, we'll try to add the inverse of every
+# install command run to here, though it's not complete.
 cat << EOF > $UNINSTALLER
 printf "It's recommended you run these steps manually.\n"
 printf "If you want to run the full script, open it in\n"
 printf "an editor and remove 'exit 1' from below.\n"
 exit 1
+source $VIRTUAL_ENV/bin/activate
 EOF
 
-if $UNSTABLE; then
-	warning "Installing unstable library from source.\n\n"
-else
-	printf "Installing stable library from pypi.\n\n"
-fi
+printf "\n"
 
 inform "Installing for $PYTHON_VER...\n"
+
+# Install apt packages from pyproject.toml / tool.pimoroni.apt_packages
 apt_pkg_install "${APT_PACKAGES[@]}"
+
+printf "\n"
+
 if $UNSTABLE; then
+	warning "Installing unstable library from source.\n"
 	pip_pkg_install .
 else
+	inform "Installing stable library from pypi.\n"
 	pip_pkg_install $LIBRARY_NAME
 fi
+
 if [ $? -eq 0 ]; then
 	success "Done!\n"
 	echo "$PYTHON -m pip uninstall $LIBRARY_NAME" >> $UNINSTALLER
@@ -201,26 +294,39 @@ fi
 
 cd $WD
 
+find_config
+
+# Run the setup commands from pyproject.toml / tool.pimoroni.commands
+
 for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 	CMD="${SETUP_CMDS[$i]}"
-	# Attempt to catch anything that touches /boot/config.txt and trigger a backup
-	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG"* ]] || [[ "$CMD" == *"\$CONFIG"* ]]; then
+	# Attempt to catch anything that touches config.txt and trigger a backup
+	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG_DIR/$CONFIG_FILE"* ]] || [[ "$CMD" == *"\$CONFIG_DIR/\$CONFIG_FILE"* ]]; then
 		do_config_backup
 	fi
 	eval $CMD
+	check_for_error
 done
+
+printf "\n"
+
+# Add the config.txt entries from pyproject.toml / tool.pimoroni.configtxt
 
 for ((i = 0; i < ${#CONFIG_TXT[@]}; i++)); do
 	CONFIG_LINE="${CONFIG_TXT[$i]}"
 	if ! [ "$CONFIG_LINE" == "" ]; then
 		do_config_backup
-		inform "Adding $CONFIG_LINE to $CONFIG\n"
-		sudo sed -i "s/^#$CONFIG_LINE/$CONFIG_LINE/" $CONFIG
-		if ! grep -q "^$CONFIG_LINE" $CONFIG; then
-			printf "$CONFIG_LINE\n" | sudo tee --append $CONFIG
+		inform "Adding $CONFIG_LINE to $CONFIG_DIR/$CONFIG_FILE"
+		sudo sed -i "s/^#$CONFIG_LINE/$CONFIG_LINE/" $CONFIG_DIR/$CONFIG_FILE
+		if ! grep -q "^$CONFIG_LINE" $CONFIG_DIR/$CONFIG_FILE; then
+			printf "$CONFIG_LINE\n" | sudo tee --append $CONFIG_DIR/$CONFIG_FILE
 		fi
 	fi
 done
+
+printf "\n"
+
+# Just a straight copy of the examples/ dir into ~/Pimoroni/board/examples
 
 if [ -d "examples" ]; then
 	if confirm "Would you like to copy examples to $RESOURCES_DIR?"; then
@@ -233,9 +339,12 @@ fi
 
 printf "\n"
 
+# Use pdoc to generate basic documentation from the installed module
+
 if confirm "Would you like to generate documentation?"; then
+	inform "Installing pdoc. Please wait..."
 	pip_pkg_install pdoc
-	printf "Generating documentation.\n"
+	inform "Generating documentation.\n"
 	$PYTHON -m pdoc $LIBRARY_NAME -o $RESOURCES_DIR/docs > /dev/null
 	if [ $? -eq 0 ]; then
 		inform "Documentation saved to $RESOURCES_DIR/docs"
@@ -245,6 +354,22 @@ if confirm "Would you like to generate documentation?"; then
 	fi
 fi
 
-success "\nAll done!"
-inform "If this is your first time installing you should reboot for hardware changes to take effect.\n"
-inform "Find uninstall steps in $UNINSTALLER\n"
+printf "\n"
+
+if [ "$CMD_ERRORS" = true ]; then
+	warning "One or more setup commands appear to have failed."
+	printf "This might prevent things from working properly.\n"
+	printf "Make sure your OS is up to date and try re-running this installer.\n"
+	printf "If things still don't work, report this or find help at $GITHUB_URL.\n\n"
+else
+	success "\nAll done!"
+fi
+
+printf "If this is your first time installing you should reboot for hardware changes to take effect.\n"
+printf "Find uninstall steps in $UNINSTALLER\n\n"
+
+if [ "$CMD_ERRORS" = true ]; then
+	exit 1
+else
+	exit 0
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ skip = """
 [tool.isort]
 line_length = 200
 
+[tool.black]
+line-length = 200
+
 [tool.check-manifest]
 ignore = [
     '.stickler.yml',
@@ -109,10 +112,10 @@ ignore = [
     'requirements-dev.txt'
 ]
 
-[pimoroni]
+[tool.pimoroni]
 apt_packages = []
 configtxt = []
 commands = [
     "printf \"Setting up i2c...\n\"",
-	"raspi-config nonint do_i2c 0"
+	"sudo raspi-config nonint do_i2c 0"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 	python -m build --no-isolation
 	python -m twine check dist/*
 	isort --check .
-	ruff --format=github .
+	ruff .
 	codespell .
 deps =
 	check-manifest

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 FORCE=false
-LIBRARY_NAME=`grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}'`
+LIBRARY_NAME=$(grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}')
 RESOURCES_DIR=$HOME/Pimoroni/$LIBRARY_NAME
 PYTHON="python"
 
 
 venv_check() {
-	PYTHON_BIN=`which $PYTHON`
+	PYTHON_BIN=$(which $PYTHON)
 	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
 		printf "This script should be run in a virtual Python environment.\n"
 		exit 1
@@ -15,7 +15,7 @@ venv_check() {
 }
 
 user_check() {
-	if [ $(id -u) -eq 0 ]; then
+	if [ "$(id -u)" -eq 0 ]; then
 		printf "Script should not be run as root. Try './uninstall.sh'\n"
 		exit 1
 	fi
@@ -55,17 +55,17 @@ warning() {
 	echo -e "$(tput setaf 1)$1$(tput sgr0)"
 }
 
-printf "$LIBRARY_NAME Python Library: Uninstaller\n\n"
+printf "%s Python Library: Uninstaller\n\n" "$LIBRARY_NAME"
 
 user_check
 venv_check
 
 printf "Uninstalling for Python 3...\n"
-$PYTHON -m pip uninstall $LIBRARY_NAME
+$PYTHON -m pip uninstall "$LIBRARY_NAME"
 
-if [ -d $RESOURCES_DIR ]; then
+if [ -d "$RESOURCES_DIR" ]; then
 	if confirm "Would you like to delete $RESOURCES_DIR?"; then
-		rm -r $RESOURCES_DIR
+		rm -r "$RESOURCES_DIR"
 	fi
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,7 +3,16 @@
 FORCE=false
 LIBRARY_NAME=`grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}'`
 RESOURCES_DIR=$HOME/Pimoroni/$LIBRARY_NAME
-PYTHON="/usr/bin/python3"
+PYTHON="python"
+
+
+venv_check() {
+	PYTHON_BIN=`which $PYTHON`
+	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
+		printf "This script should be run in a virtual Python environment.\n"
+		exit 1
+	fi
+}
 
 user_check() {
 	if [ $(id -u) -eq 0 ]; then
@@ -49,6 +58,7 @@ warning() {
 printf "$LIBRARY_NAME Python Library: Uninstaller\n\n"
 
 user_check
+venv_check
 
 printf "Uninstalling for Python 3...\n"
 $PYTHON -m pip uninstall $LIBRARY_NAME


### PR DESCRIPTION
# Testing

If you're a Bookworm / Pi 5 user running into virtual environment issues, you can try this library like so:

```
git clone https://github.com/pimoroni/scd4x-python -b repackage
cd scd4x-python
./install.sh --unstable
```

The `./install.sh` script will create a `pimoroni` virtual environment that's shared between our products. (or use your existing venv if you've already activated one.)

For the reasons behind these changes and other information, see:

* https://github.com/pimoroni/boilerplate-python/pull/13
* https://github.com/pimoroni/boilerplate-python/issues/16
* https://pimoroni.github.io/venv-python/